### PR TITLE
Adds an enum to track the new visual editor being disabled.

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.0.19"
+  s.version      = "0.0.20"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEditorDiscardedChanges,
     WPAnalyticsStatEditorEditedImage,
     WPAnalyticsStatEditorEnabledNewVersion,
+    WPAnalyticsStatEditorDisabledNewVersion,
     WPAnalyticsStatEditorPublishedPost,
     WPAnalyticsStatEditorSavedDraft,
     WPAnalyticsStatEditorScheduledPost,


### PR DESCRIPTION
...and bumps the podspec version to 0.0.20.

The lack of this enum was causing issues in WPiOS, so I had to manually disable some code until this is pushed and added to WPiOS.

This is the first PR to fix [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3165).

/cc @bummytime 