### PR TITLE
Removed published post with events in favor of using properties

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.0.35"
+  s.version      = "0.0.36"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -151,7 +151,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
 };
 
 extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyCategory;
-extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyImage;
+extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyPhoto;
 extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyTag;
 extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo;
 

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -95,10 +95,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatPostListStatusFilterChanged,
     WPAnalyticsStatPostListTrashAction,
     WPAnalyticsStatPostListViewAction,
-    WPAnalyticsStatPublishedPostWithCategories,
-    WPAnalyticsStatPublishedPostWithPhoto,
-    WPAnalyticsStatPublishedPostWithTags,
-    WPAnalyticsStatPublishedPostWithVideo,
     WPAnalyticsStatPushAuthenticationApproved,
     WPAnalyticsStatPushAuthenticationExpired,
     WPAnalyticsStatPushAuthenticationFailed,
@@ -150,8 +146,14 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatThemesAccessedThemeBrowser,
     WPAnalyticsStatThemesChangedTheme,
     WPAnalyticsStatTwoFactorCodeRequested,
-    WPAnalyticsStatTwoFactorSentSMS
+    WPAnalyticsStatTwoFactorSentSMS,
+    WPAnalyticsStatMaxValue
 };
+
+extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyCategory;
+extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyImage;
+extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyTag;
+extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo;
 
 @protocol WPAnalyticsTracker;
 @interface WPAnalytics : NSObject

--- a/WordPressCom-Analytics-iOS/WPAnalytics.m
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.m
@@ -1,5 +1,10 @@
 #import "WPAnalytics.h"
 
+NSString *const WPAnalyticsStatEditorPublishedPostPropertyCategory = @"with_categories";
+NSString *const WPAnalyticsStatEditorPublishedPostPropertyPhoto = @"with_photos";
+NSString *const WPAnalyticsStatEditorPublishedPostPropertyTag = @"with_tags";
+NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo = @"with_videos";
+
 @implementation WPAnalytics
 
 + (NSMutableArray *)trackers


### PR DESCRIPTION
Closes #31 & #27

Added constants for with_categories, with_tags, with_photos, with_videos and removed the corresponding events. WPiOS will use properties to describe a post being published with `WPAnalyticsStatEditorPublishedPost` and attach the properties as booleans.

Needs Review: @bummytime 