### PR TITLE
Reverts framework fix

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.0.40"
+  s.version      = "0.0.41"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
   s.source_files  = "WordPressCom-Analytics-iOS", "WordPressCom-Analytics-iOS/**/*.{h,m}"
   s.prefix_header_file = "WordPressCom-Analytics-iOS/WordPressCom-Analytics-iOS-Prefix.pch"
   s.requires_arc = true
-  s.header_dir = 'WordPressComAnalytics'
 end


### PR DESCRIPTION
Reverts #39 

This effectively reverts the changes made to support frameworks. The version number should have been bumped to `0.1.0` to prevent breaking of podspecs in develop. This will get pushed to trunk and another PR to bump the framework changes into 0.1.0.

:dancer: :dancers: Yay dependencies!