### PR TITLE
Version bump for previous additions.

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.3"
+  s.version      = “0.1.4”
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }


### PR DESCRIPTION
Forgot to add a version bump in https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS/pull/50

Bumping to `0.1.4`

Please review @astralbodies 