### PR TITLE
Issue/fix typo

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.7"
+  s.version      = "0.1.8"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -148,7 +148,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatSharingButtonOrderChanged,
     WPAnalyticsStatSharingButtonShowReblogChanged,
     WPAnalyticsStatSharingOpenedPublicize,
-    WPAnaltycisStatSharingOpenedSharingButtonSettings,
+    WPAnalyticsStatSharingOpenedSharingButtonSettings,
     WPAnalyticsStatSharingPublicizeConnected,
     WPAnalyticsStatSharingPublicizeDisconnected,
     WPAnalyticsStatSharingPublicizeConnectionAvailableToAllChanged,


### PR DESCRIPTION
A typo sneaked past us in an earlier commit and was causing build errors in the main WordPress app.  Swift was unable to see the `WPAnalyticsStat` enum. The typo apparently prevented Swift from extracting the enum's `WPAnalyticsStat` prefix.

Fixing the typo and bumping the podspec to use version 0.1.8. 