### PR TITLE
Removed Today Extension enums

### DIFF
--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -198,9 +198,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatThemesDetailsAccessed,
     WPAnalyticsStatThemesPreviewedSite,
     WPAnalyticsStatThemesSupportAccessed,
-    WPAnalyticsStatTodayExtensionAccessed,
-    WPAnalyticsStatTodayExtensionConfigureLaunched,
-    WPAnalyticsStatTodayExtensionStatsLaunched,
     WPAnalyticsStatTwoFactorCodeRequested,
     WPAnalyticsStatTwoFactorSentSMS,
     WPAnalyticsStatMaxValue


### PR DESCRIPTION
Mistakenly added this to the enum - turns out I need to use static event names in the today extension.