### PR TITLE
Revert "Added Today Extension analytics events"

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.2.0"
+  s.version      = "0.1.9"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -198,9 +198,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatThemesDetailsAccessed,
     WPAnalyticsStatThemesPreviewedSite,
     WPAnalyticsStatThemesSupportAccessed,
-    WPAnalyticsStatTodayExtensionAccessed,
-    WPAnalyticsStatTodayExtensionConfigureLaunched,
-    WPAnalyticsStatTodayExtensionStatsLaunched,
     WPAnalyticsStatTwoFactorCodeRequested,
     WPAnalyticsStatTwoFactorSentSMS,
     WPAnalyticsStatMaxValue


### PR DESCRIPTION
Reverts wordpress-mobile/WordPressCom-Analytics-iOS#62