### PR TITLE
Menus: Remove unused stat for tracking a menu name

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.13"
+  s.version      = "0.1.14"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -73,7 +73,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatMenusOpenedItemEditor,
     WPAnalyticsStatMenusOrderedItems,
     WPAnalyticsStatMenusSavedMenu,
-    WPAnalyticsStatMenusUpdatedMenuName,
     WPAnalyticsStatNotificationsCommentApproved,
     WPAnalyticsStatNotificationsCommentFlaggedAsSpam,
     WPAnalyticsStatNotificationsCommentLiked,


### PR DESCRIPTION
Removing a stat for menus that couldn't be tracked accurately or without overly-complicating the tracking code. We may re-add this in the future.

@astralbodies can you review real quick? 🕵