### PR TITLE
Media: add missing resized photo stats

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.22"
+  s.version      = "0.1.23"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -36,6 +36,8 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEditorPublishedPost,
     WPAnalyticsStatEditorQuickPublishedPost,
     WPAnalyticsStatEditorQuickSavedDraft,
+    WPAnalyticsStatEditorResizedPhoto,
+    WPAnalyticsStatEditorResizedPhotoError,
     WPAnalyticsStatEditorSavedDraft,
     WPAnalyticsStatEditorScheduledPost,
     WPAnalyticsStatEditorTappedBlockquote,


### PR DESCRIPTION
Adds enums already apart of Android analytics, but not currently used on iOS.

I'll go ahead and request a review actually: @astralbodies just for a quick peak