### PR TITLE
Stats for actions on empty notifications

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.23"
+  s.version      = "0.1.24"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -92,6 +92,8 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatNotificationsCommentUnapproved,
     WPAnalyticsStatNotificationsCommentUnliked,
     WPAnalyticsStatNotificationsMissingSyncWarning,
+    WPAnalyticsStatNotificationsTappedNewPost,
+    WPAnalyticsStatNotificationsTappedViewReader,
     WPAnalyticsStatNotificationsSettingsUpdated,
     WPAnalyticsStatNotificationsSiteFollowAction,
     WPAnalyticsStatNotificationsSiteUnfollowAction,


### PR DESCRIPTION
Adds two new stats to track tapping on the action buttons on the notifications screen when there are no notifications.
Here you can see the action that triggers them:

![simulator screen shot mar 22 2017 15 20 53](https://cloud.githubusercontent.com/assets/5558824/24214144/700f5c14-0f13-11e7-8d84-c4e983f99a3f.png) ![simulator screen shot mar 22 2017 15 20 59](https://cloud.githubusercontent.com/assets/5558824/24214148/7274b698-0f13-11e7-805f-15e55bef3ce2.png)