### PR TITLE
Stat for scheduling from post list

### DIFF
--- a/WordPressCom-Analytics-iOS.podspec
+++ b/WordPressCom-Analytics-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Analytics-iOS"
-  s.version      = "0.1.26"
+  s.version      = "0.1.27"
   s.summary      = "Library for handling Analytics tracking in WPiOS"
   s.homepage     = "http://apps.wordpress.org"
   s.license      = { :type => "GPLv2" }

--- a/WordPressCom-Analytics-iOS/WPAnalytics.h
+++ b/WordPressCom-Analytics-iOS/WPAnalytics.h
@@ -152,6 +152,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatPostListNoResultsButtonPressed,
     WPAnalyticsStatPostListOpenedCellMenu,
     WPAnalyticsStatPostListPublishAction,
+    WPAnalyticsStatPostListScheduleAction,
     WPAnalyticsStatPostListPullToRefresh,
     WPAnalyticsStatPostListRestoreAction,
     WPAnalyticsStatPostListSearchOpened,


### PR DESCRIPTION
Adding a new stat needed to track the action of scheduling a post from the post list.
Needed for: https://github.com/wordpress-mobile/WordPress-iOS/issues/6326